### PR TITLE
Midi 126/finetuning

### DIFF
--- a/configs/T5denoise-dstart.yaml
+++ b/configs/T5denoise-dstart.yaml
@@ -1,23 +1,26 @@
 train:
   num_epochs: 5
-  accum_iter: 10
-  batch_size: 8
+  accum_iter: 5
+  batch_size: 2
   base_lr: 3e-5
-  finetune: True
   warmup: 4000
+  finetune: False
 
-
-pretrained_checkpoint: midi-T5-2023-11-15-17-18git status.pt
 model_name: T5
 dataset_name: 'roszcz/maestro-v1-sustain'
-target: velocity
+target: denoise
 seed: 26
-time_bins: 100
 
 overfit: False
 
-tokens_per_note: "single"
+tokens_per_note: single
 time_quantization_method: dstart
+masking_probability: 0.2
+mask: tokens
+
+encoder: velocity
+time_bins: 100
+
 dataset:
   sequence_len: 128
   sequence_step: 42
@@ -25,7 +28,7 @@ dataset:
   quantization:
     dstart: 5
     duration: 5
-    velocity: 5
+    velocity: 3
 
 device: "cuda:0"
 
@@ -39,5 +42,4 @@ model:
   d_kv: 64
   d_ff: 2048
   num_layers: 6
-  num_decoder_layers: None
   num_heads: 8

--- a/configs/T5denoise-dstart.yaml
+++ b/configs/T5denoise-dstart.yaml
@@ -37,6 +37,7 @@ log_frequency: 10
 run_name: midi-T5-${now:%Y-%m-%d-%H-%M}
 project: "midi-hf-transformer"
 
+pre_defined_model: null
 model:
   d_model: 512
   d_kv: 64

--- a/configs/T5denoise.yaml
+++ b/configs/T5denoise.yaml
@@ -17,7 +17,7 @@ time_quantization_method: start
 masking_probability: 0.15
 mask: notes
 
-encoder: start
+encoder: velocity
 time_bins: 100
 
 dataset:

--- a/configs/T5denoise.yaml
+++ b/configs/T5denoise.yaml
@@ -4,6 +4,7 @@ train:
   batch_size: 8
   base_lr: 3e-5
   warmup: 4000
+  finetune: False
 
 model_name: T5
 dataset_name: 'roszcz/maestro-v1-sustain'

--- a/configs/T5denoise.yaml
+++ b/configs/T5denoise.yaml
@@ -26,9 +26,9 @@ dataset:
   sequence_step: 2
 
   quantization:
-    start: 20
+    start: 50
     duration: 5
-    velocity: 5
+    velocity: 3
 
 device: "cuda:0"
 

--- a/configs/T5denoise.yaml
+++ b/configs/T5denoise.yaml
@@ -17,6 +17,9 @@ time_quantization_method: start
 masking_probability: 0.15
 mask: notes
 
+encoder: start
+time_bins: 100
+
 dataset:
   sequence_duration: 5
   sequence_step: 2

--- a/configs/T5denoise.yaml
+++ b/configs/T5denoise.yaml
@@ -37,6 +37,8 @@ log_frequency: 10
 run_name: midi-T5-${now:%Y-%m-%d-%H-%M}
 project: "midi-hf-transformer"
 
+pre_defined_model: null
+
 model:
   d_model: 512
   d_kv: 64

--- a/configs/T5start.yaml
+++ b/configs/T5start.yaml
@@ -31,6 +31,8 @@ log_frequency: 10
 run_name: midi-T5-${now:%Y-%m-%d-%H-%M}
 project: "midi-hf-transformer"
 
+pre_defined_model: null
+
 model:
   d_model: 512
   d_kv: 64

--- a/configs/T5velocity-dstart.yaml
+++ b/configs/T5velocity-dstart.yaml
@@ -7,7 +7,7 @@ train:
   warmup: 4000
 
 
-pretrained_checkpoint: midi-T5-2023-11-15-17-18git status.pt
+pretrained_checkpoint: midi-T5-2023-11-15-17-18.pt
 model_name: T5
 dataset_name: 'roszcz/maestro-v1-sustain'
 target: velocity

--- a/configs/T5velocity-dstart.yaml
+++ b/configs/T5velocity-dstart.yaml
@@ -34,6 +34,8 @@ log_frequency: 10
 run_name: midi-T5-${now:%Y-%m-%d-%H-%M}
 project: "midi-hf-transformer"
 
+pre_defined_model: null
+
 model:
   d_model: 512
   d_kv: 64

--- a/configs/T5velocity.yaml
+++ b/configs/T5velocity.yaml
@@ -6,7 +6,7 @@ train:
   warmup: 4000
   finetune: True
 
-pretrained_checkpoint: midi-T5-2023-11-07-12-53.pt
+pretrained_checkpoint: midi-T5-2023-11-10-14-39.pt
 model_name: T5
 dataset_name: 'roszcz/maestro-v1-sustain'
 target: velocity

--- a/configs/T5velocity.yaml
+++ b/configs/T5velocity.yaml
@@ -4,7 +4,9 @@ train:
   batch_size: 8
   base_lr: 3e-4
   warmup: 4000
+  finetune: True
 
+pretrained_checkpoint: midi-T5-2023-11-07-12-53.pt
 model_name: T5
 dataset_name: 'roszcz/maestro-v1-sustain'
 target: velocity

--- a/configs/T5velocity.yaml
+++ b/configs/T5velocity.yaml
@@ -32,6 +32,8 @@ log_frequency: 10
 run_name: midi-T5-${now:%Y-%m-%d-%H-%M}
 project: "midi-hf-transformer"
 
+pre_defined_model: null
+
 model:
   d_model: 512
   d_kv: 64

--- a/configs/T5velocity.yaml
+++ b/configs/T5velocity.yaml
@@ -6,7 +6,7 @@ train:
   warmup: 4000
   finetune: True
 
-pretrained_checkpoint: midi-T5-2023-11-10-14-39.pt
+pretrained_checkpoint: midi-T5-2023-11-11-10-29.pt
 model_name: T5
 dataset_name: 'roszcz/maestro-v1-sustain'
 target: velocity

--- a/configs/architectures/large.yaml
+++ b/configs/architectures/large.yaml
@@ -1,0 +1,5 @@
+d_model: 512
+d_kv: 64
+d_ff: 2048
+num_layers: 6
+num_heads: 8

--- a/configs/architectures/mid.yaml
+++ b/configs/architectures/mid.yaml
@@ -1,0 +1,5 @@
+d_model: 256
+d_kv: 32
+d_ff: 1024
+num_layers: 6
+num_heads: 8

--- a/configs/architectures/small.yaml
+++ b/configs/architectures/small.yaml
@@ -1,0 +1,5 @@
+d_model: 256
+d_kv: 32
+d_ff: 512
+num_layers: 4
+num_heads: 4

--- a/dashboard/denoise/main.py
+++ b/dashboard/denoise/main.py
@@ -193,7 +193,7 @@ def model_predictions_review(
         pred_piece.source = true_piece.source.copy()
 
         # create a dashboard
-        st.json(record_source)
+        st.json(record_source, expanded=False)
         cols = st.columns(2)
 
         source_tokens: list[str] = [dataset.encoder.vocab[idx] for idx in src_token_ids]

--- a/dashboard/denoise/main.py
+++ b/dashboard/denoise/main.py
@@ -164,6 +164,9 @@ def model_predictions_review(
 
     # predict velocities and get src, tgt and model output
     print("Making predictions ...")
+
+    # widget id for streamlit_pianoroll widget
+    key = 0
     for record_id in idxs:
         # Numpy to int :(
         record: dict = dataset.get_complete_record(int(record_id))
@@ -199,10 +202,11 @@ def model_predictions_review(
         source_tokens: list[str] = [dataset.encoder.vocab[idx] for idx in src_token_ids]
         tgt_tokens: list[str] = [dataset.encoder.vocab[idx] for idx in record["target_token_ids"]]
         generated_tokens: list[str] = [dataset.encoder.vocab[idx] for idx in generated_token_ids]
+
         with cols[0]:
-            fig = ff.view.draw_dual_pianoroll(true_piece)
+            fig = ff.view.draw_pianoroll_with_velocities(true_piece)
             st.pyplot(fig)
-            from_fortepyan(true_piece)
+            from_fortepyan(true_piece, key=key)
             # Unchanged
             st.markdown("**Source tokens:**")
             st.markdown(source_tokens)
@@ -214,9 +218,10 @@ def model_predictions_review(
 
             fig = ff.view.draw_dual_pianoroll(pred_piece)
             st.pyplot(fig)
-            from_fortepyan(pred_piece)
+            from_fortepyan(pred_piece, key=key + 1)
             st.markdown("**Predicted tokens:**")
             st.markdown(generated_tokens)
+        key += 2
 
 
 if __name__ == "__main__":

--- a/dashboard/denoise/main.py
+++ b/dashboard/denoise/main.py
@@ -212,7 +212,6 @@ def model_predictions_review(
 
             fig = ff.view.draw_dual_pianoroll(pred_piece)
             st.pyplot(fig)
-            print(pred_piece)
             from_fortepyan(pred_piece)
             st.markdown("**Predicted tokens:**")
             st.markdown(generated_tokens)

--- a/dashboard/denoise/main.py
+++ b/dashboard/denoise/main.py
@@ -13,7 +13,7 @@ from transformers import T5Config, T5ForConditionalGeneration
 
 from utils import vocab_size, piece_av_files
 from data.midiencoder import QuantizedMidiEncoder
-from data.multitokencoder import MultiVelocityEncoder
+from data.multitokencoder import MultiMidiEncoder
 from data.quantizer import MidiQuantizer, MidiATQuantizer
 from data.dataset import MaskedMidiDataset, load_cache_dataset
 from data.maskedmidiencoder import MaskedMidiEncoder, MaskedNoteEncoder
@@ -105,7 +105,7 @@ def model_predictions_review(
             n_dstart_bins=dataset_cfg.quantization.dstart,
         )
     if train_cfg.tokens_per_note == "multiple":
-        base_tokenizer = MultiVelocityEncoder(
+        base_tokenizer = MultiMidiEncoder(
             quantization_cfg=train_cfg.dataset.quantization,
             time_quantization_method=train_cfg.time_quantization_method,
         )

--- a/dashboard/denoise/main.py
+++ b/dashboard/denoise/main.py
@@ -200,6 +200,8 @@ def model_predictions_review(
         tgt_tokens: list[str] = [dataset.encoder.vocab[idx] for idx in record["target_token_ids"]]
         generated_tokens: list[str] = [dataset.encoder.vocab[idx] for idx in generated_token_ids]
         with cols[0]:
+            fig = ff.view.draw_dual_pianoroll(true_piece)
+            st.pyplot(fig)
             from_fortepyan(true_piece)
             # Unchanged
             st.markdown("**Source tokens:**")

--- a/dashboard/download_models.py
+++ b/dashboard/download_models.py
@@ -1,6 +1,6 @@
 from huggingface_hub import hf_hub_download
 
-FILENAME_VELOCITY = "midi-T5-2023-10-20-16-03.pt"
+FILENAME_VELOCITY = "velocity-T5-2023-11-11-10-29.pt"
 FILENAME_DENOISE = "midi-T5-2023-11-11-10-29.pt"
 
 hf_hub_download(

--- a/dashboard/download_models.py
+++ b/dashboard/download_models.py
@@ -1,7 +1,7 @@
 from huggingface_hub import hf_hub_download
 
 FILENAME_VELOCITY = "midi-T5-2023-10-20-16-03.pt"
-FILENAME_DENOISE = "midi-T5-2023-11-07-12-53.pt"
+FILENAME_DENOISE = "midi-T5-2023-11-11-10-29.pt"
 
 hf_hub_download(
     repo_id="wmatejuk/midi-T5-velocity",

--- a/dashboard/download_models.py
+++ b/dashboard/download_models.py
@@ -1,10 +1,18 @@
 from huggingface_hub import hf_hub_download
 
 FILENAME_VELOCITY = "velocity-T5-2023-11-11-10-29.pt"
+FILENAME_DENOISE = "midi-T5-2023-11-11-10-29.pt"
+
 
 hf_hub_download(
     repo_id="wmatejuk/midi-T5-velocity",
     filename=FILENAME_VELOCITY,
     local_dir="checkpoints/velocity",
+    local_dir_use_symlinks=False,
+)
+hf_hub_download(
+    repo_id="wmatejuk/midi-T5-denoise",
+    filename=FILENAME_DENOISE,
+    local_dir="checkpoints/denoise",
     local_dir_use_symlinks=False,
 )

--- a/dashboard/download_models.py
+++ b/dashboard/download_models.py
@@ -1,18 +1,10 @@
 from huggingface_hub import hf_hub_download
 
 FILENAME_VELOCITY = "velocity-T5-2023-11-11-10-29.pt"
-FILENAME_DENOISE = "midi-T5-2023-11-11-10-29.pt"
 
 hf_hub_download(
     repo_id="wmatejuk/midi-T5-velocity",
     filename=FILENAME_VELOCITY,
     local_dir="checkpoints/velocity",
-    local_dir_use_symlinks=False,
-)
-
-hf_hub_download(
-    repo_id="wmatejuk/midi-T5-denoise",
-    filename=FILENAME_DENOISE,
-    local_dir="checkpoints/denoise",
     local_dir_use_symlinks=False,
 )

--- a/dashboard/velocity/main.py
+++ b/dashboard/velocity/main.py
@@ -53,7 +53,7 @@ def main():
     st.markdown("Dataset config:")
     st.json(dataset_params, expanded=True)
 
-    if train_cfg.train.finetune:
+    if "finetune" in train_cfg.train and train_cfg.train.finetune:
         tokenizer = MultiMidiEncoder(
             quantization_cfg=train_cfg.dataset.quantization,
             time_quantization_method=train_cfg.time_quantization_method,

--- a/dashboard/velocity/main.py
+++ b/dashboard/velocity/main.py
@@ -203,7 +203,7 @@ def model_predictions_review(
         pred_piece.source = true_piece.source.copy()
 
         # create a dashboard
-        st.json(record_source)
+        st.json(record_source, expanded=False)
         cols = st.columns(2)
         with cols[0]:
             # Unchanged

--- a/dashboard/velocity/main.py
+++ b/dashboard/velocity/main.py
@@ -11,12 +11,11 @@ from fortepyan import MidiPiece
 from omegaconf import OmegaConf, DictConfig
 from transformers import T5Config, T5ForConditionalGeneration
 
-from data.quantizer import MidiATQuantizer
 from data.midiencoder import VelocityEncoder
 from utils import vocab_size, piece_av_files
-from data.multitokencoder import MultiVelocityEncoder, MultiMidiEncoder
 from data.maskedmidiencoder import MaskedMidiEncoder
 from data.dataset import MyTokenizedMidiDataset, load_cache_dataset
+from data.multitokencoder import MultiMidiEncoder, MultiVelocityEncoder
 
 # Set the layout of the Streamlit page
 st.set_page_config(layout="wide", page_title="Velocity Transformer", page_icon=":musical_keyboard")
@@ -112,7 +111,7 @@ def model_predictions_review(
     model: nn.Module,
     train_cfg: DictConfig,
     model_dir: str,
-    tokenizer: MultiVelocityEncoder | MultiMidiEncoder | VelocityEncoder
+    tokenizer: MultiVelocityEncoder | MultiMidiEncoder | VelocityEncoder,
 ):
     # load checkpoint, force dashboard device
     dataset_cfg = train_cfg.dataset

--- a/dashboard/velocity/main.py
+++ b/dashboard/velocity/main.py
@@ -5,14 +5,16 @@ import json
 import torch
 import numpy as np
 import pandas as pd
-import torch.nn as nn
+import fortepyan as ff
+
 import streamlit as st
 from fortepyan import MidiPiece
 from omegaconf import OmegaConf, DictConfig
+from streamlit_pianoroll import from_fortepyan
 from transformers import T5Config, T5ForConditionalGeneration
 
 from data.midiencoder import VelocityEncoder
-from utils import vocab_size, piece_av_files
+from utils import vocab_size
 from data.maskedmidiencoder import MaskedMidiEncoder
 from data.dataset import MyTokenizedMidiDataset, load_cache_dataset
 from data.multitokencoder import MultiMidiEncoder, MultiVelocityEncoder
@@ -36,7 +38,7 @@ def main():
     with st.sidebar:
         # Show available checkpoints
         options = glob.glob("checkpoints/velocity/*.pt")
-        options.sort()
+        options.sort(reverse=True)
         checkpoint_path = st.selectbox(label="model", options=options)
         st.markdown("Selected checkpoint:")
         st.markdown(checkpoint_path)
@@ -52,6 +54,37 @@ def main():
     dataset_params = OmegaConf.to_container(train_cfg.dataset)
     st.markdown("Dataset config:")
     st.json(dataset_params, expanded=True)
+
+    # Folder to render audio and video
+    model_dir = f"tmp/dashboard/{train_cfg.run_name}"
+
+    if not os.path.exists(model_dir):
+        os.mkdir(model_dir)
+
+    if mode == "Sequence predictions":
+        model_predictions_review(
+            checkpoint=checkpoint,
+            train_cfg=train_cfg,
+        )
+
+
+def model_predictions_review(
+    checkpoint: dict,
+    train_cfg: DictConfig,
+):
+    # load checkpoint, force dashboard device
+    dataset_cfg = train_cfg.dataset
+    dataset_name = st.text_input(label="dataset", value=train_cfg.dataset_name)
+    split = st.text_input(label="split", value="test")
+
+    random_seed = st.selectbox(label="random seed", options=range(20))
+
+    # load translation dataset and create MyTokenizedMidiDataset
+    val_translation_dataset = load_cache_dataset(
+        dataset_cfg=dataset_cfg,
+        dataset_name=dataset_name,
+        split=split,
+    )
 
     if "finetune" in train_cfg.train and train_cfg.train.finetune:
         tokenizer = MultiMidiEncoder(
@@ -75,14 +108,47 @@ def main():
             quantization_cfg=train_cfg.dataset.quantization,
             time_quantization_method=train_cfg.time_quantization_method,
         )
-    cls_token_id = tokenizer.token_to_id["<CLS>"]
-    pad_token_id = tokenizer.token_to_id["<PAD>"]
+
+    dataset = MyTokenizedMidiDataset(
+        dataset=val_translation_dataset,
+        dataset_cfg=train_cfg.dataset,
+        encoder=tokenizer,
+    )
+    start_token_id: int = dataset.encoder.token_to_id["<CLS>"]
+    pad_token_id: int = dataset.encoder.token_to_id["<PAD>"]
     config = T5Config(
         vocab_size=vocab_size(train_cfg),
-        decoder_start_token_id=cls_token_id,
-        eos_token_id=pad_token_id,
+        decoder_start_token_id=start_token_id,
         pad_token_id=pad_token_id,
+        eos_token_id=pad_token_id,
         use_cache=False,
+        d_model=train_cfg.model.d_model,
+        d_kv=train_cfg.model.d_kv,
+        d_ff=train_cfg.model.d_ff,
+        num_layers=train_cfg.model.num_layers,
+        num_heads=train_cfg.model.num_heads,
+    )
+
+    model = T5ForConditionalGeneration(config)
+    model.load_state_dict(checkpoint["model_state_dict"])
+    model.eval().to(DEVICE)
+
+    n_parameters: float = sum(p.numel() for p in model.parameters()) / 1e6
+    st.markdown(f"Model parameters: {n_parameters:.3f}M")
+
+    start_token_id: int = dataset.encoder.token_to_id["<CLS>"]
+    pad_token_id: int = dataset.encoder.token_to_id["<PAD>"]
+    config = T5Config(
+        vocab_size=vocab_size(train_cfg),
+        decoder_start_token_id=start_token_id,
+        pad_token_id=pad_token_id,
+        eos_token_id=pad_token_id,
+        use_cache=False,
+        d_model=train_cfg.model.d_model,
+        d_kv=train_cfg.model.d_kv,
+        d_ff=train_cfg.model.d_ff,
+        num_layers=train_cfg.model.num_layers,
+        num_heads=train_cfg.model.num_heads,
     )
 
     model = T5ForConditionalGeneration(config)
@@ -91,47 +157,6 @@ def main():
 
     n_parameters = sum(p.numel() for p in model.parameters()) / 1e6
     st.markdown(f"Model parameters: {n_parameters:.3f}M")
-
-    # Folder to render audio and video
-    model_dir = f"tmp/dashboard/{train_cfg.run_name}"
-
-    if not os.path.exists(model_dir):
-        os.mkdir(model_dir)
-
-    if mode == "Sequence predictions":
-        model_predictions_review(
-            model=model,
-            train_cfg=train_cfg,
-            model_dir=model_dir,
-            tokenizer=tokenizer,
-        )
-
-
-def model_predictions_review(
-    model: nn.Module,
-    train_cfg: DictConfig,
-    model_dir: str,
-    tokenizer: MultiVelocityEncoder | MultiMidiEncoder | VelocityEncoder,
-):
-    # load checkpoint, force dashboard device
-    dataset_cfg = train_cfg.dataset
-    dataset_name = st.text_input(label="dataset", value=train_cfg.dataset_name)
-    split = st.text_input(label="split", value="test")
-
-    random_seed = st.selectbox(label="random seed", options=range(20))
-
-    # load translation dataset and create MyTokenizedMidiDataset
-    val_translation_dataset = load_cache_dataset(
-        dataset_cfg=dataset_cfg,
-        dataset_name=dataset_name,
-        split=split,
-    )
-
-    dataset = MyTokenizedMidiDataset(
-        dataset=val_translation_dataset,
-        dataset_cfg=train_cfg.dataset,
-        encoder=tokenizer,
-    )
 
     n_samples = 5
     np.random.seed(random_seed)
@@ -157,7 +182,7 @@ def model_predictions_review(
             max_length = len(src_token_ids)
         generated_velocity = model.generate(src_token_ids.unsqueeze(0), max_length=max_length)
         generated_velocity = generated_velocity.squeeze(0)
-        decoded_velocity = tokenizer.decode_tgt(generated_velocity)
+        generated_velocity = tokenizer.decode_tgt(generated_velocity)
 
         # TODO start here
         # Reconstruct the sequence as recorded
@@ -169,7 +194,7 @@ def model_predictions_review(
         pred_piece_df = true_piece.df.copy()
 
         # change untokenized velocities to model predictions
-        pred_piece_df["velocity"] = decoded_velocity
+        pred_piece_df["velocity"] = generated_velocity
         pred_piece_df["velocity"] = pred_piece_df["velocity"].fillna(0)
 
         # create quantized piece with predicted velocities
@@ -177,34 +202,20 @@ def model_predictions_review(
 
         pred_piece.source = true_piece.source.copy()
 
-        # create files
-        true_save_base = os.path.join(model_dir, f"true_{record_id}")
-        true_piece_paths = piece_av_files(piece=true_piece, save_base=true_save_base)
-
-        predicted_save_base = os.path.join(model_dir, f"predicted_{record_id}")
-        predicted_paths = piece_av_files(piece=pred_piece, save_base=predicted_save_base)
-
         # create a dashboard
         st.json(record_source)
         cols = st.columns(2)
-        source_tokens: list[str] = [dataset.encoder.vocab[idx] for idx in src_token_ids]
-        tgt_tokens: list[str] = [dataset.encoder.vocab[idx] for idx in record["target_token_ids"]]
-        generated_tokens: list[str] = [dataset.encoder.vocab[idx] for idx in generated_velocity]
         with cols[0]:
             # Unchanged
-            st.image(true_piece_paths["pianoroll_path"])
-            st.audio(true_piece_paths["mp3_path"])
-            st.markdown("**Source tokens:**")
-            st.markdown(source_tokens)
-            st.markdown("**Target tokens:**")
-            st.markdown(tgt_tokens)
+            fig = ff.view.draw_pianoroll_with_velocities(true_piece)
+            st.pyplot(fig)
+            from_fortepyan(true_piece)
 
         with cols[1]:
             # Predicted
-            st.image(predicted_paths["pianoroll_path"])
-            st.audio(predicted_paths["mp3_path"])
-            st.markdown("**Predicted tokens:**")
-            st.markdown(generated_tokens)
+            fig = ff.view.draw_pianoroll_with_velocities(pred_piece)
+            st.pyplot(fig)
+            from_fortepyan(pred_piece)
 
 
 if __name__ == "__main__":

--- a/dashboard/velocity/main.py
+++ b/dashboard/velocity/main.py
@@ -6,15 +6,14 @@ import torch
 import numpy as np
 import pandas as pd
 import fortepyan as ff
-
 import streamlit as st
 from fortepyan import MidiPiece
 from omegaconf import OmegaConf, DictConfig
 from streamlit_pianoroll import from_fortepyan
 from transformers import T5Config, T5ForConditionalGeneration
 
-from data.midiencoder import VelocityEncoder
 from utils import vocab_size
+from data.midiencoder import VelocityEncoder
 from data.maskedmidiencoder import MaskedMidiEncoder
 from data.dataset import MyTokenizedMidiDataset, load_cache_dataset
 from data.multitokencoder import MultiMidiEncoder, MultiVelocityEncoder

--- a/data/maskedmidiencoder.py
+++ b/data/maskedmidiencoder.py
@@ -11,7 +11,7 @@ class MaskedMidiEncoder:
         self.base_encoder = base_encoder
         self.masking_probability = masking_probability
         self.num_sentinel: int = 100
-
+        self.specials = [f"<SENTINEL_{idx}>" for idx in range(self.num_sentinel)] + ["<MASK>"] + base_encoder.specials
         self.vocab = [f"<SENTINEL_{idx}>" for idx in range(self.num_sentinel)] + ["<MASK>"] + base_encoder.vocab
 
         # add midi tokens to vocab

--- a/data/maskedmidiencoder.py
+++ b/data/maskedmidiencoder.py
@@ -89,15 +89,21 @@ class MaskedMidiEncoder:
         src_it: int = 0
         tgt_it: int = 0
         token_ids: list[int] = []
+        mask_ids: list[int] = []
+        note_it: int = 0
         while src_it < len(src_token_ids) and tgt_it < len(tgt_token_ids):
             if src_token_ids[src_it] < self.num_sentinel:
                 while tgt_it < len(tgt_token_ids) and tgt_token_ids[tgt_it] >= self.num_sentinel:
                     token_ids.append(tgt_token_ids[tgt_it])
+                    mask_ids.append(note_it)
+
+                    note_it += 1
                     tgt_it += 1
                 src_it += 1
             elif tgt_token_ids[tgt_it] < self.num_sentinel:
                 while src_it < len(src_token_ids) and src_token_ids[src_it] >= self.num_sentinel:
                     token_ids.append(src_token_ids[src_it])
+                    note_it += 1
                     src_it += 1
                 tgt_it += 1
             else:
@@ -105,7 +111,11 @@ class MaskedMidiEncoder:
                 tgt_it += 1
 
         tokens: list[str] = [self.vocab[token_id] for token_id in token_ids]
-        return self.base_encoder.untokenize_src(tokens)
+        df: pd.DataFrame = self.base_encoder.untokenize_src(tokens)
+        mask_ids_column = np.zeros_like(df["pitch"], dtype=bool)
+        mask_ids_column[mask_ids] = True
+        df["mask"] = mask_ids_column
+        return df
 
 
 class MaskedNoteEncoder(MaskedMidiEncoder):

--- a/data/maskedmidiencoder.py
+++ b/data/maskedmidiencoder.py
@@ -1,6 +1,6 @@
-import pandas as pd
 import torch
 import numpy as np
+import pandas as pd
 
 from data.midiencoder import MidiEncoder
 from data.multitokencoder import MultiTokEncoder
@@ -10,7 +10,7 @@ class MaskedMidiEncoder:
     def __init__(self, base_encoder: MultiTokEncoder | MidiEncoder, masking_probability: float = 0.15):
         self.base_encoder = base_encoder
         self.masking_probability = masking_probability
-        self.num_sentinel = 100
+        self.num_sentinel: int = 100
 
         self.vocab = [f"<SENTINEL_{idx}>" for idx in range(self.num_sentinel)] + ["<MASK>"] + base_encoder.vocab
 

--- a/data/midiencoder.py
+++ b/data/midiencoder.py
@@ -9,6 +9,7 @@ class MidiEncoder:
         self.token_to_id = None
         self.vocab = None
         self.time_key = None
+        self.specials = None
 
     def tokenize_src(self, record: dict) -> list[str]:
         raise NotImplementedError("Your encoder needs *tokenize* implementation")

--- a/pipelines/T5/main.py
+++ b/pipelines/T5/main.py
@@ -132,7 +132,9 @@ def create_masked_datasets(
         base_encoder=base_encoder,
         encoder=encoder,
     )
-
+    print(len(train_dataset.encoder.vocab))
+    print(vocab_size(cfg))
+    
     val_dataset = MaskedMidiDataset(
         dataset=val_translation_dataset,
         dataset_cfg=cfg.dataset,
@@ -158,7 +160,7 @@ def create_datasets_finetune(
     # use the same token ids as used during pre-training
     tokenizer.vocab = pretraining_tokenizer.vocab
     tokenizer.token_to_id = pretraining_tokenizer.token_to_id
-
+    print(len(tokenizer.vocab))
     train_dataset = MyTokenizedMidiDataset(
         dataset=train_translation_dataset,
         dataset_cfg=cfg.dataset,

--- a/pipelines/T5/main.py
+++ b/pipelines/T5/main.py
@@ -29,7 +29,7 @@ def main(
         # make current cfg fit pre-train cfg
         pretrain_cfg.device = cfg.device
         pretrain_cfg.target = cfg.target
-        pretrain_cfg.train.append({"finetune": True})
+        pretrain_cfg.train.finetune = True
         pretrain_cfg.run_name = cfg.run_name
         cfg = pretrain_cfg
 

--- a/pipelines/T5/main.py
+++ b/pipelines/T5/main.py
@@ -26,10 +26,13 @@ def main(
     elif cfg.train.finetune:
         checkpoint = torch.load(f"checkpoints/denoise/{cfg.pretrained_checkpoint}", map_location=cfg.device)
         pretrain_cfg = OmegaConf.create(checkpoint["cfg"])
+        # make current cfg fit pre-train cfg
         pretrain_cfg.device = cfg.device
         pretrain_cfg.target = cfg.target
         pretrain_cfg.train.append({"finetune": True})
+        pretrain_cfg.run_name = cfg.run_name
         cfg = pretrain_cfg
+
         train_dataset, val_dataset = create_datasets_finetune(
             cfg=cfg,
             train_translation_dataset=train_translation_dataset,

--- a/pipelines/T5/main.py
+++ b/pipelines/T5/main.py
@@ -132,7 +132,7 @@ def create_masked_datasets(
         base_encoder=base_encoder,
         encoder=encoder,
     )
-    
+
     val_dataset = MaskedMidiDataset(
         dataset=val_translation_dataset,
         dataset_cfg=cfg.dataset,

--- a/pipelines/T5/main.py
+++ b/pipelines/T5/main.py
@@ -30,6 +30,7 @@ def main(
         pretrain_cfg.device = cfg.device
         pretrain_cfg.target = cfg.target
         pretrain_cfg.train.finetune = True
+        pretrain_cfg.train.base_lr = cfg.train.base_lr
         pretrain_cfg.run_name = cfg.run_name
         cfg = pretrain_cfg
 

--- a/pipelines/T5/main.py
+++ b/pipelines/T5/main.py
@@ -28,7 +28,7 @@ def main(
         pretrain_cfg = OmegaConf.create(checkpoint["cfg"])
         pretrain_cfg.device = cfg.device
         pretrain_cfg.target = cfg.target
-        pretrain_cfg.train.finetune = True
+        pretrain_cfg.train.append({"finetune": True})
         cfg = pretrain_cfg
         train_dataset, val_dataset = create_datasets_finetune(
             cfg=cfg,

--- a/pipelines/T5/main.py
+++ b/pipelines/T5/main.py
@@ -45,6 +45,9 @@ def main(
             train_translation_dataset=train_translation_dataset,
             val_translation_dataset=val_translation_dataset,
         )
+    if cfg.pre_defined_model is not None:
+        model_cfg = OmegaConf.load(f"configs/architectures/{cfg.pre_defined_model}.yaml")
+        cfg.model = model_cfg
 
     start_token_id: int = train_dataset.encoder.token_to_id["<CLS>"]
     pad_token_id: int = train_dataset.encoder.token_to_id["<PAD>"]

--- a/pipelines/T5/main.py
+++ b/pipelines/T5/main.py
@@ -132,8 +132,6 @@ def create_masked_datasets(
         base_encoder=base_encoder,
         encoder=encoder,
     )
-    print(len(train_dataset.encoder.vocab))
-    print(vocab_size(cfg))
     
     val_dataset = MaskedMidiDataset(
         dataset=val_translation_dataset,
@@ -160,7 +158,6 @@ def create_datasets_finetune(
     # use the same token ids as used during pre-training
     tokenizer.vocab = pretraining_tokenizer.vocab
     tokenizer.token_to_id = pretraining_tokenizer.token_to_id
-    print(len(tokenizer.vocab))
     train_dataset = MyTokenizedMidiDataset(
         dataset=train_translation_dataset,
         dataset_cfg=cfg.dataset,

--- a/pipelines/T5/main.py
+++ b/pipelines/T5/main.py
@@ -26,7 +26,7 @@ def main(
     elif cfg.train.finetune:
         checkpoint = torch.load(f"checkpoints/denoise/{cfg.pretrained_checkpoint}", map_location=cfg.device)
         pretrain_cfg = OmegaConf.create(checkpoint["cfg"])
-        # make current cfg fit pre-train cfg
+        # make current cfg fit pre-train cfg but keep relevant info from current config
         pretrain_cfg.device = cfg.device
         pretrain_cfg.target = cfg.target
         pretrain_cfg.train.finetune = True

--- a/pipelines/T5/main.py
+++ b/pipelines/T5/main.py
@@ -1,5 +1,6 @@
+import torch
 from datasets import Dataset
-from omegaconf import DictConfig
+from omegaconf import OmegaConf, DictConfig
 from transformers import T5Config, T5ForConditionalGeneration
 
 from utils import vocab_size
@@ -7,7 +8,7 @@ from training_utils import train_model
 from data.dataset import MaskedMidiDataset, MyTokenizedMidiDataset
 from data.midiencoder import VelocityEncoder, QuantizedMidiEncoder
 from data.maskedmidiencoder import MaskedMidiEncoder, MaskedNoteEncoder
-from data.multitokencoder import MultiStartEncoder, MultiVelocityEncoder
+from data.multitokencoder import MultiMidiEncoder, MultiStartEncoder, MultiVelocityEncoder
 
 
 def main(
@@ -15,8 +16,21 @@ def main(
     train_translation_dataset: Dataset,
     val_translation_dataset: Dataset,
 ):
+    checkpoint = None
     if cfg.target == "denoise":
         train_dataset, val_dataset = create_masked_datasets(
+            cfg=cfg,
+            train_translation_dataset=train_translation_dataset,
+            val_translation_dataset=val_translation_dataset,
+        )
+    elif cfg.train.finetune:
+        checkpoint = torch.load(f"checkpoints/denoise/{cfg.pretrained_checkpoint}", map_location=cfg.device)
+        pretrain_cfg = OmegaConf.create(checkpoint["cfg"])
+        pretrain_cfg.device = cfg.device
+        pretrain_cfg.target = cfg.target
+        pretrain_cfg.train.finetune = True
+        cfg = pretrain_cfg
+        train_dataset, val_dataset = create_datasets_finetune(
             cfg=cfg,
             train_translation_dataset=train_translation_dataset,
             val_translation_dataset=val_translation_dataset,
@@ -27,6 +41,7 @@ def main(
             train_translation_dataset=train_translation_dataset,
             val_translation_dataset=val_translation_dataset,
         )
+
     start_token_id: int = train_dataset.encoder.token_to_id["<CLS>"]
     pad_token_id: int = train_dataset.encoder.token_to_id["<PAD>"]
     config = T5Config(
@@ -43,6 +58,11 @@ def main(
     )
 
     model = T5ForConditionalGeneration(config)
+    if checkpoint is not None:
+        # Pre-trained model has to be trained with the same vocab_size as our model.
+        # To do that, pre-trained model has to be trained using a base_encoder,
+        # initialized the same way as our tokenizer.
+        model.load_state_dict(checkpoint["model_state_dict"])
 
     train_model(
         model=model,
@@ -96,7 +116,9 @@ def create_masked_datasets(
     val_translation_dataset: Dataset,
 ) -> tuple[MyTokenizedMidiDataset, MyTokenizedMidiDataset]:
     if cfg.tokens_per_note == "multiple":
-        base_encoder = MultiStartEncoder(cfg.dataset.quantization, cfg.time_quantization_method, tgt_bins=0)
+        base_encoder = MultiMidiEncoder(
+            quantization_cfg=cfg.dataset.quantization, time_quantization_method=cfg.time_quantization_method
+        )
     else:
         base_encoder = QuantizedMidiEncoder(cfg.dataset.quantization, cfg.time_quantization_method)
     if cfg.mask == "notes":
@@ -116,6 +138,36 @@ def create_masked_datasets(
         dataset_cfg=cfg.dataset,
         base_encoder=base_encoder,
         encoder=encoder,
+    )
+
+    return train_dataset, val_dataset
+
+
+def create_datasets_finetune(
+    cfg: DictConfig,
+    train_translation_dataset: Dataset,
+    val_translation_dataset: Dataset,
+) -> tuple[MyTokenizedMidiDataset, MyTokenizedMidiDataset]:
+    tokenizer = MultiMidiEncoder(
+        quantization_cfg=cfg.dataset.quantization,
+        time_quantization_method=cfg.time_quantization_method,
+    )
+    pretraining_tokenizer = MaskedMidiEncoder(
+        base_encoder=tokenizer,
+    )
+    # use the same token ids as used during pre-training
+    tokenizer.vocab = pretraining_tokenizer.vocab
+    tokenizer.token_to_id = pretraining_tokenizer.token_to_id
+
+    train_dataset = MyTokenizedMidiDataset(
+        dataset=train_translation_dataset,
+        dataset_cfg=cfg.dataset,
+        encoder=tokenizer,
+    )
+    val_dataset = MyTokenizedMidiDataset(
+        dataset=val_translation_dataset,
+        dataset_cfg=cfg.dataset,
+        encoder=tokenizer,
     )
 
     return train_dataset, val_dataset

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ omegaconf~=2.3.0
 pandas~=2.0.0
 PyYAML~=5.4.1
 streamlit~=1.25.0
-torch~=2.0.0
+torch~=2.1.1
 tqdm~=4.65.0
 transformers~=4.28.1
 

--- a/utils.py
+++ b/utils.py
@@ -50,7 +50,7 @@ def vocab_size(cfg: DictConfig):
     # 88 pitches
     size: int = 88
 
-    if cfg.target == "denoise" or cfg.train.finetune:
+    if cfg.target == "denoise" or ("finetune" in cfg.train and cfg.train.finetune):
         size += 101  # 100 sentinel tokens and 1 mask token
         size += 128  # velocity tokens
         size += cfg.time_bins * 10  # start * duration or dstart * duration

--- a/utils.py
+++ b/utils.py
@@ -68,6 +68,12 @@ def vocab_size(cfg: DictConfig):
 
         return size
 
+    return vocab_size_classic(cfg)
+
+
+def vocab_size_classic(cfg: DictConfig):
+    # 88 pitches
+    size: int = 88
     if cfg.tokens_per_note == "single":
         # product size
         size = size * cfg.dataset.quantization[cfg.time_quantization_method]
@@ -94,6 +100,9 @@ def vocab_size(cfg: DictConfig):
     if cfg.target == "start":
         size += cfg.start_bins
 
+    if cfg.target == "denoise":
+        # add 100 sentinel tokens and 1 mask token
+        size += 101
     return size
 
 

--- a/utils.py
+++ b/utils.py
@@ -49,6 +49,13 @@ def piece_av_files(piece: MidiPiece, save_base: str) -> dict:
 def vocab_size(cfg: DictConfig):
     # 88 pitches
     size: int = 88
+
+    if cfg.target == "denoise" or cfg.train.finetune:
+        size += 101  # 100 sentinel tokens and 1 mask token
+        size += 128  # velocity tokens
+        size += cfg.time_bins * 10  # start * duration or dstart * duration
+        return size
+
     if cfg.tokens_per_note == "single":
         # product size
         size = size * cfg.dataset.quantization[cfg.time_quantization_method]
@@ -75,9 +82,6 @@ def vocab_size(cfg: DictConfig):
     if cfg.target == "start":
         size += cfg.start_bins
 
-    if cfg.target == "denoise":
-        # add 100 sentinel tokens and 1 mask token
-        size += 101
     return size
 
 

--- a/utils.py
+++ b/utils.py
@@ -51,11 +51,20 @@ def vocab_size(cfg: DictConfig):
     size: int = 88
 
     if cfg.target == "denoise" or ("finetune" in cfg.train and cfg.train.finetune):
-        size += 101  # 100 sentinel tokens and 1 mask token
+        if cfg.tokens_per_note == "single":
+            # product size
+            size = size * cfg.dataset.quantization[cfg.time_quantization_method]
+            size = size * cfg.dataset.quantization.duration
+            size = size * cfg.dataset.quantization.velocity
+            # velocity tokens
+            size += 128
+            size += cfg.time_bins * 10
+            size += 103
+            return size
+        size += 103  # 100 sentinel tokens, 1 mask token and 2 special tokens
         size += 128  # velocity tokens
         size += cfg.time_bins * 10  # start * duration or dstart * duration
         size += cfg.time_bins
-        size += 2  # special tokens
 
         return size
 

--- a/utils.py
+++ b/utils.py
@@ -54,6 +54,7 @@ def vocab_size(cfg: DictConfig):
         size += 101  # 100 sentinel tokens and 1 mask token
         size += 128  # velocity tokens
         size += cfg.time_bins * 10  # start * duration or dstart * duration
+        size += cfg.time_bins
         size += 2  # special tokens
 
         return size

--- a/utils.py
+++ b/utils.py
@@ -54,6 +54,8 @@ def vocab_size(cfg: DictConfig):
         size += 101  # 100 sentinel tokens and 1 mask token
         size += 128  # velocity tokens
         size += cfg.time_bins * 10  # start * duration or dstart * duration
+        size += 2  # special tokens
+
         return size
 
     if cfg.tokens_per_note == "single":

--- a/utils.py
+++ b/utils.py
@@ -91,12 +91,13 @@ def vocab_size(cfg: DictConfig):
 def calculate_average_distance(out: torch.Tensor, tgt: torch.Tensor, pad_idx: int = 1) -> torch.Tensor:
     labels = out.argmax(1).to(float)
     tgt[tgt == -100] = pad_idx
+    tgt = tgt[tgt != pad_idx]
+    # make labels fixed length same as target
+    labels = labels[: len(tgt)]
 
     # remove special tokens
     labels[tgt == pad_idx] = pad_idx
 
-    # make labels fixed length same as target
-    labels = labels[: len(tgt)]
     # average distance between label and target
     return torch.dist(labels, tgt.to(float), p=1) / len(labels)
 


### PR DESCRIPTION
### Finetuning

T5 was originally pre-trained with denoising objective and then fine-tuned to specific NLP tasks. The idea behind this part of the project is to make our own version of pre-training and fine-tuning T5.

#### Configuration:
##### Configs
run `python3 train.py` with --config-name flag to use different training pipelines:
```command
python3 train.py --config-name T5velocity  // velocity prediction, quantization on start values.
python3 train.py --config-name T5velocity-dstart // quantization with dstart
python3 train.py --config-name T5denoise // denoising objective, quantization on start values
python3 train.py --config-name T5denoise-dstart // quantization with dstart
```

##### Important hyperparameters:
`time_quantization_method`: start or dstart. DO NOT SET MANUALLY, use a config with -dstart suffix instead.
`tokens_per_note` : single or multiple.

`train.finetue` : if `False`, classic training with according vocabulary, if `True` - training with a full musical vocabulary consisting of 128 velocity bins, `time_bins` start or dstart tokens (depending on `time_quantization_method`), all the possible source tokens.
